### PR TITLE
ocimotel: be compatible with zot

### DIFF
--- a/ocimotel/image_dest.go
+++ b/ocimotel/image_dest.go
@@ -74,17 +74,17 @@ func (o *ociMotelImageDest) PutBlob(ctx context.Context, stream io.Reader, input
 		}
 	}
 
-	fmt.Printf("calling startlayer\n");
+	fmt.Printf("calling startlayer\n")
 	// Do this as a chunked upload so we can calculate the digest, since
 	// caller is not giving it to us.
 	path, err := o.s.StartLayer()
-	fmt.Printf("callled startlayer and got %s %v\n", path, err);
+	fmt.Printf("callled startlayer and got %s %v\n", path, err)
 	if err != nil {
 		return types.BlobInfo{}, err
 	}
-	digest, size, err := o.s.CompleteLayer(path, stream)
+	digest, size, err := o.s.CompleteLayer(path, stream, inputInfo.Size)
 	fmt.Printf("callled completelayer and got %v %d %v\n", digest, size, err)
-	return types.BlobInfo{ Digest: digest, Size: size}, err
+	return types.BlobInfo{Digest: digest, Size: size}, err
 }
 
 // HasThreadSafePutBlob indicates whether PutBlob can be executed concurrently.

--- a/ocimotel/image_src.go
+++ b/ocimotel/image_src.go
@@ -44,7 +44,7 @@ func (o *ociMotelImageSource) GetManifest(ctx context.Context, instanceDigest *d
 }
 
 func (o *ociMotelImageSource) GetBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache) (io.ReadCloser, int64, error) {
-	digest := info.Digest.Encoded()
+	digest := info.Digest.String()
 	return o.s.GetLayer(digest)
 }
 


### PR DESCRIPTION
mainly, compliant with opencontainers/distribution-spec (WIP)
zot currently uses a flat <image>:<tag> naming
add a go.mod