### PR TITLE
ocimotel: preserve existing layer compression

### DIFF
--- a/ocimotel/image_dest.go
+++ b/ocimotel/image_dest.go
@@ -38,7 +38,7 @@ func (o *ociMotelImageDest) SupportsSignatures(ctx context.Context) error {
 }
 
 func (o *ociMotelImageDest) DesiredLayerCompression() types.LayerCompression {
-	return types.Compress
+	return types.PreserveOriginal
 }
 
 func (o *ociMotelImageDest) AcceptsForeignLayerURLs() bool {


### PR DESCRIPTION
By default this tells containers/image "please compress everything that's
not currently a gzip stream", which will break when we insert atomfs layers
into zot, since squashfs != gzip. Since they're already compressed, we can
just leave things as-is.

Signed-off-by: Tycho Andersen <tycho@tycho.ws>